### PR TITLE
Feat. 서버와 앱클라이언트 연결과 전역상태 추가

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -5,6 +5,7 @@ import 'package:provider/provider.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
 
 import 'package:krosscutting_app/provider/video_path_provider.dart';
+import 'package:krosscutting_app/provider/video_direction_provider.dart';
 
 import 'package:krosscutting_app/screens/select_screen/video_manager.dart';
 import 'package:krosscutting_app/screens/album_screen.dart';
@@ -32,6 +33,7 @@ class App extends StatelessWidget {
 
     return MultiProvider(
       providers: [
+        ChangeNotifierProvider(create: (context) => VideoDirectionProvider()),
         ChangeNotifierProvider(create: (context) => VideoPathProvider()),
         ChangeNotifierProvider(create: (context) {
           final videoPathProvider =

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -35,14 +35,7 @@ class App extends StatelessWidget {
       providers: [
         ChangeNotifierProvider(create: (context) => VideoDirectionProvider()),
         ChangeNotifierProvider(create: (context) => VideoPathProvider()),
-        ChangeNotifierProvider(create: (context) {
-          final videoPathProvider =
-              Provider.of<VideoPathProvider>(context, listen: false);
-
-          final selectedPaths = videoPathProvider.videoPath.values.toList();
-
-          return VideoManager(selectedPaths);
-        }),
+        ChangeNotifierProvider(create: (context) => VideoManager([])),
       ],
       child: MaterialApp(
         title: "KrossCutting",

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -8,7 +8,7 @@ import 'package:krosscutting_app/provider/video_path_provider.dart';
 import 'package:krosscutting_app/provider/video_direction_provider.dart';
 
 import 'package:krosscutting_app/screens/select_screen/video_manager.dart';
-import 'package:krosscutting_app/screens/album_screen.dart';
+import 'package:krosscutting_app/screens/album_screen/album_screen.dart';
 import 'package:krosscutting_app/screens/home_screen/home_screen.dart';
 import 'package:krosscutting_app/screens/splash_screen.dart';
 import 'package:krosscutting_app/screens/select_screen/video_select_start_point.dart';

--- a/lib/provider/video_direction_provider.dart
+++ b/lib/provider/video_direction_provider.dart
@@ -1,0 +1,14 @@
+import 'package:flutter/material.dart';
+import 'package:krosscutting_app/constants/type.dart';
+
+class VideoDirectionProvider with ChangeNotifier {
+  String _directionType = BUTTON_TYPE.VERTICAL;
+
+  void setVideoDirection(direction) {
+    _directionType = direction;
+
+    notifyListeners();
+  }
+
+  String get direction => _directionType;
+}

--- a/lib/screens/album_screen/album_screen.dart
+++ b/lib/screens/album_screen/album_screen.dart
@@ -1,7 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:permission_handler/permission_handler.dart';
 
-import 'package:krosscutting_app/widgets/imbedded_album.dart';
+import 'package:krosscutting_app/screens/album_screen/embedded_album.dart';
+import 'package:krosscutting_app/screens/album_screen/grant_button.dart';
 
 class AlbumScreen extends StatefulWidget {
   const AlbumScreen({super.key});
@@ -100,7 +101,7 @@ class _AlbumScreenState extends State<AlbumScreen> {
                   ],
                 ),
                 hasPermission
-                    ? const ImbeddedAlbum()
+                    ? const EmbeddedAlbum()
                     : Center(
                         child: GrantButton(
                           onClickGrantButton: onClickGrantButton,
@@ -111,62 +112,6 @@ class _AlbumScreenState extends State<AlbumScreen> {
           ),
         ),
       ),
-    );
-  }
-}
-
-class GrantButton extends StatelessWidget {
-  final Function()? onClickGrantButton;
-
-  const GrantButton({
-    super.key,
-    this.onClickGrantButton,
-  });
-
-  @override
-  Widget build(BuildContext context) {
-    return Column(
-      mainAxisAlignment: MainAxisAlignment.center,
-      crossAxisAlignment: CrossAxisAlignment.center,
-      children: [
-        const SizedBox(
-          height: 100,
-        ),
-        Container(
-          decoration: BoxDecoration(
-            shape: BoxShape.rectangle,
-            borderRadius: BorderRadius.circular(45),
-            border: const Border(
-              top: BorderSide(
-                color: Colors.purple,
-                width: 2.0,
-              ),
-              bottom: BorderSide(
-                color: Colors.purple,
-                width: 2.0,
-              ),
-              left: BorderSide(
-                color: Colors.purple,
-                width: 2.0,
-              ),
-              right: BorderSide(
-                color: Colors.purple,
-                width: 2.0,
-              ),
-            ),
-          ),
-          child: TextButton(
-            onPressed: onClickGrantButton,
-            child: const Text(
-              "Get Permission",
-              style: TextStyle(
-                fontSize: 30,
-                fontFamily: "notoSansItalic",
-              ),
-            ),
-          ),
-        ),
-      ],
     );
   }
 }

--- a/lib/screens/album_screen/embedded_album.dart
+++ b/lib/screens/album_screen/embedded_album.dart
@@ -1,7 +1,6 @@
 import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
-import 'package:image_picker/image_picker.dart';
 import 'package:http/http.dart' as http;
 import 'package:flutter_dotenv/flutter_dotenv.dart';
 
@@ -9,17 +8,18 @@ import 'package:krosscutting_app/constants/type.dart';
 import 'package:krosscutting_app/provider/video_path_provider.dart';
 import 'package:krosscutting_app/widgets/gradient_button.dart';
 import 'package:krosscutting_app/screens/select_screen/video_manager.dart';
+import 'package:krosscutting_app/screens/album_screen/selection_row.dart';
 
-class ImbeddedAlbum extends StatefulWidget {
-  const ImbeddedAlbum({
+class EmbeddedAlbum extends StatefulWidget {
+  const EmbeddedAlbum({
     super.key,
   });
 
   @override
-  State<ImbeddedAlbum> createState() => _ImbeddedAlbumState();
+  State<EmbeddedAlbum> createState() => _EmbeddedAlbumState();
 }
 
-class _ImbeddedAlbumState extends State<ImbeddedAlbum> {
+class _EmbeddedAlbumState extends State<EmbeddedAlbum> {
   bool isAllSelected = false;
 
   @override
@@ -28,6 +28,7 @@ class _ImbeddedAlbumState extends State<ImbeddedAlbum> {
   }
 
   void uploadFile(videoPathMap, context) async {
+    //TODO: endPoints | 수정 app/videos/contents/files
     var url = Uri.parse("${dotenv.env["SERVER_HOST"]}/videos/contents/files");
     var request = http.MultipartRequest("POST", url);
 
@@ -51,10 +52,9 @@ class _ImbeddedAlbumState extends State<ImbeddedAlbum> {
 
     if (response.statusCode == 200) {
       updateVideoManager(context);
-
       Navigator.pushNamed(context, "/selection/startpoint");
     } else {
-      //TO DO: 유저에게 안내
+      //TODO: 유저에게 안내
     }
   }
 
@@ -98,98 +98,5 @@ class _ImbeddedAlbumState extends State<ImbeddedAlbum> {
               )
       ],
     );
-  }
-}
-
-class SelectionRow extends StatefulWidget {
-  final Map type;
-
-  const SelectionRow({
-    super.key,
-    required this.type,
-  });
-
-  @override
-  State<SelectionRow> createState() => _SelectionRowState();
-}
-
-class _SelectionRowState extends State<SelectionRow> {
-  @override
-  Widget build(BuildContext context) {
-    Size screenSize = MediaQuery.of(context).size;
-
-    return SizedBox(
-      height: screenSize.height * 0.13,
-      child: Row(
-        mainAxisAlignment: MainAxisAlignment.spaceBetween,
-        children: [
-          Text(
-            widget.type["buttonName"],
-            style: TextStyle(
-              fontSize: screenSize.height * 0.04,
-            ),
-          ),
-          SelectButton(
-            typeKey: widget.type["key"],
-          ),
-        ],
-      ),
-    );
-  }
-}
-
-class SelectButton extends StatefulWidget {
-  final String typeKey;
-
-  const SelectButton({
-    super.key,
-    required this.typeKey,
-  });
-
-  @override
-  State<SelectButton> createState() => _SelectButtonState();
-}
-
-class _SelectButtonState extends State<SelectButton> {
-  @override
-  Widget build(BuildContext context) {
-    final videoPathProvider = Provider.of<VideoPathProvider>(context);
-    final videoPathMap = videoPathProvider.videoPath;
-    bool isSelected = videoPathMap[widget.typeKey] != null;
-
-    Future<void> pickFiles() async {
-      XFile? selectedVideo =
-          await ImagePicker().pickVideo(source: ImageSource.gallery);
-
-      if (selectedVideo != null) {
-        videoPathProvider.setVideoPath(widget.typeKey, selectedVideo.path);
-      }
-    }
-
-    return isSelected
-        ? Row(
-            children: [
-              const Icon(
-                Icons.check_circle,
-                size: 40,
-                color: Colors.deepPurple,
-              ),
-              IconButton(
-                onPressed: pickFiles,
-                icon: const Icon(
-                  Icons.replay_circle_filled_rounded,
-                  size: 40,
-                  color: Color.fromARGB(255, 30, 233, 209),
-                ),
-              ),
-            ],
-          )
-        : IconButton(
-            icon: const Icon(
-              size: 40,
-              Icons.video_collection_rounded,
-            ),
-            onPressed: pickFiles,
-          );
   }
 }

--- a/lib/screens/album_screen/embedded_album.dart
+++ b/lib/screens/album_screen/embedded_album.dart
@@ -49,10 +49,8 @@ class _EmbeddedAlbumState extends State<EmbeddedAlbum> {
 
     var response = await request.send();
 
-    if (response.statusCode == 201) {
-      updateVideoManager(context);
-    } else {
-      //TODO: 유저에게 안내
+    if (response.statusCode != 201) {
+      print("응답에러발생");
     }
   }
 
@@ -88,6 +86,7 @@ class _EmbeddedAlbumState extends State<EmbeddedAlbum> {
             ? GradientButton(
                 buttonText: "NEXT",
                 onClick: () {
+                  updateVideoManager(context);
                   Navigator.pushNamed(context, "/selection/startpoint");
                   uploadFile(videoPathMap, context);
                 },

--- a/lib/screens/album_screen/embedded_album.dart
+++ b/lib/screens/album_screen/embedded_album.dart
@@ -28,7 +28,6 @@ class _EmbeddedAlbumState extends State<EmbeddedAlbum> {
   }
 
   void uploadFile(videoPathMap, context) async {
-    //TODO: endPoints | 수정 app/videos/contents/files
     var url = Uri.parse("${dotenv.env["SERVER_HOST"]}/videos/contents/files");
     var request = http.MultipartRequest("POST", url);
 
@@ -50,9 +49,8 @@ class _EmbeddedAlbumState extends State<EmbeddedAlbum> {
 
     var response = await request.send();
 
-    if (response.statusCode == 200) {
+    if (response.statusCode == 201) {
       updateVideoManager(context);
-      Navigator.pushNamed(context, "/selection/startpoint");
     } else {
       //TODO: 유저에게 안내
     }
@@ -90,6 +88,7 @@ class _EmbeddedAlbumState extends State<EmbeddedAlbum> {
             ? GradientButton(
                 buttonText: "NEXT",
                 onClick: () {
+                  Navigator.pushNamed(context, "/selection/startpoint");
                   uploadFile(videoPathMap, context);
                 },
               )

--- a/lib/screens/album_screen/grant_button.dart
+++ b/lib/screens/album_screen/grant_button.dart
@@ -1,0 +1,57 @@
+import 'package:flutter/material.dart';
+
+class GrantButton extends StatelessWidget {
+  final Function()? onClickGrantButton;
+
+  const GrantButton({
+    super.key,
+    this.onClickGrantButton,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      mainAxisAlignment: MainAxisAlignment.center,
+      crossAxisAlignment: CrossAxisAlignment.center,
+      children: [
+        const SizedBox(
+          height: 100,
+        ),
+        Container(
+          decoration: BoxDecoration(
+            shape: BoxShape.rectangle,
+            borderRadius: BorderRadius.circular(45),
+            border: const Border(
+              top: BorderSide(
+                color: Colors.purple,
+                width: 2.0,
+              ),
+              bottom: BorderSide(
+                color: Colors.purple,
+                width: 2.0,
+              ),
+              left: BorderSide(
+                color: Colors.purple,
+                width: 2.0,
+              ),
+              right: BorderSide(
+                color: Colors.purple,
+                width: 2.0,
+              ),
+            ),
+          ),
+          child: TextButton(
+            onPressed: onClickGrantButton,
+            child: const Text(
+              "Get Permission",
+              style: TextStyle(
+                fontSize: 30,
+                fontFamily: "notoSansItalic",
+              ),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/screens/album_screen/select_button.dart
+++ b/lib/screens/album_screen/select_button.dart
@@ -1,0 +1,61 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'package:image_picker/image_picker.dart';
+
+import 'package:krosscutting_app/provider/video_path_provider.dart';
+
+class SelectButton extends StatefulWidget {
+  final String typeKey;
+
+  const SelectButton({
+    super.key,
+    required this.typeKey,
+  });
+
+  @override
+  State<SelectButton> createState() => _SelectButtonState();
+}
+
+class _SelectButtonState extends State<SelectButton> {
+  @override
+  Widget build(BuildContext context) {
+    final videoPathProvider = Provider.of<VideoPathProvider>(context);
+    final videoPathMap = videoPathProvider.videoPath;
+    bool isSelected = videoPathMap[widget.typeKey] != null;
+
+    Future<void> pickFiles() async {
+      XFile? selectedVideo =
+          await ImagePicker().pickVideo(source: ImageSource.gallery);
+
+      if (selectedVideo != null) {
+        videoPathProvider.setVideoPath(widget.typeKey, selectedVideo.path);
+      }
+    }
+
+    return isSelected
+        ? Row(
+            children: [
+              const Icon(
+                Icons.check_circle,
+                size: 40,
+                color: Colors.deepPurple,
+              ),
+              IconButton(
+                onPressed: pickFiles,
+                icon: const Icon(
+                  Icons.replay_circle_filled_rounded,
+                  size: 40,
+                  color: Color.fromARGB(255, 30, 233, 209),
+                ),
+              ),
+            ],
+          )
+        : IconButton(
+            icon: const Icon(
+              size: 40,
+              Icons.video_collection_rounded,
+            ),
+            onPressed: pickFiles,
+          );
+  }
+}

--- a/lib/screens/album_screen/selection_row.dart
+++ b/lib/screens/album_screen/selection_row.dart
@@ -1,0 +1,40 @@
+import 'package:flutter/material.dart';
+
+import 'package:krosscutting_app/screens/album_screen/select_button.dart';
+
+class SelectionRow extends StatefulWidget {
+  final Map type;
+
+  const SelectionRow({
+    super.key,
+    required this.type,
+  });
+
+  @override
+  State<SelectionRow> createState() => _SelectionRowState();
+}
+
+class _SelectionRowState extends State<SelectionRow> {
+  @override
+  Widget build(BuildContext context) {
+    Size screenSize = MediaQuery.of(context).size;
+
+    return SizedBox(
+      height: screenSize.height * 0.13,
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+        children: [
+          Text(
+            widget.type["buttonName"],
+            style: TextStyle(
+              fontSize: screenSize.height * 0.04,
+            ),
+          ),
+          SelectButton(
+            typeKey: widget.type["key"],
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/screens/home_screen/home_button_peach.dart
+++ b/lib/screens/home_screen/home_button_peach.dart
@@ -13,18 +13,19 @@ class HomeButtonPeach extends StatelessWidget {
     return InkWell(
       onTap: onPressed,
       child: Container(
-        width: 140,
-        height: 240,
+        width: 300,
+        height: 120,
         decoration: BoxDecoration(
           borderRadius: BorderRadius.circular(24),
           gradient: const LinearGradient(
             colors: [
-              Color.fromRGBO(83, 183, 235, 1),
+              Color.fromRGBO(242, 194, 125, 1),
+              Color.fromRGBO(234, 101, 128, 1),
               Color.fromRGBO(148, 95, 241, 1),
-              Color.fromRGBO(204, 204, 255, 1),
+              Color.fromRGBO(83, 183, 235, 1),
             ],
-            begin: Alignment.topRight,
-            end: Alignment.bottomLeft,
+            begin: Alignment.topLeft,
+            end: Alignment.bottomRight,
           ),
         ),
         child: Column(
@@ -39,9 +40,6 @@ class HomeButtonPeach extends StatelessWidget {
                 color: Colors.white,
                 size: 50,
               ),
-            ),
-            const SizedBox(
-              height: 16,
             ),
             const Text(
               "16 : 9",

--- a/lib/screens/home_screen/home_button_purple.dart
+++ b/lib/screens/home_screen/home_button_purple.dart
@@ -13,19 +13,18 @@ class HomeButtonPurple extends StatelessWidget {
     return InkWell(
       onTap: onPressed,
       child: Container(
-        width: 300,
-        height: 120,
+        width: 140,
+        height: 240,
         decoration: BoxDecoration(
           borderRadius: BorderRadius.circular(24),
           gradient: const LinearGradient(
             colors: [
-              Color.fromRGBO(242, 194, 125, 1),
-              Color.fromRGBO(234, 101, 128, 1),
-              Color.fromRGBO(148, 95, 241, 1),
               Color.fromRGBO(83, 183, 235, 1),
+              Color.fromRGBO(148, 95, 241, 1),
+              Color.fromRGBO(204, 204, 255, 1),
             ],
-            begin: Alignment.topLeft,
-            end: Alignment.bottomRight,
+            begin: Alignment.topRight,
+            end: Alignment.bottomLeft,
           ),
         ),
         child: Column(
@@ -40,6 +39,9 @@ class HomeButtonPurple extends StatelessWidget {
                 color: Colors.white,
                 size: 50,
               ),
+            ),
+            const SizedBox(
+              height: 16,
             ),
             const Text(
               "9 : 16",

--- a/lib/screens/home_screen/home_screen.dart
+++ b/lib/screens/home_screen/home_screen.dart
@@ -1,16 +1,22 @@
 import 'package:flutter/material.dart';
 import 'package:ionicons/ionicons.dart';
 import 'package:flutter/widgets.dart';
+import 'package:provider/provider.dart';
+
+import 'package:krosscutting_app/provider/video_direction_provider.dart';
+import 'package:krosscutting_app/constants/type.dart';
 import 'package:krosscutting_app/screens/home_screen/home_button_dotted.dart';
 import 'package:krosscutting_app/screens/home_screen/home_button_green.dart';
-import 'package:krosscutting_app/screens/home_screen/home_button_peach.dart';
 import 'package:krosscutting_app/screens/home_screen/home_button_purple.dart';
+import 'package:krosscutting_app/screens/home_screen/home_button_peach.dart';
 
 class HomeScreen extends StatelessWidget {
   const HomeScreen({super.key});
 
   @override
   Widget build(BuildContext context) {
+    final videoDirection = Provider.of<VideoDirectionProvider>(context);
+
     return Scaffold(
       backgroundColor: Colors.black,
       body: Center(
@@ -26,9 +32,10 @@ class HomeScreen extends StatelessWidget {
             const SizedBox(
               height: 48,
             ),
-            HomeButtonPurple(
+            HomeButtonPeach(
               icon: Ionicons.phone_landscape_outline,
               onPressed: () {
+                videoDirection.setVideoDirection(BUTTON_TYPE.HORIZONTAL);
                 Navigator.pushNamed(context, "/album");
               },
             ),
@@ -39,9 +46,10 @@ class HomeScreen extends StatelessWidget {
               mainAxisAlignment: MainAxisAlignment.center,
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
-                HomeButtonPeach(
+                HomeButtonPurple(
                   icon: Ionicons.phone_portrait_outline,
                   onPressed: () {
+                    videoDirection.setVideoDirection(BUTTON_TYPE.VERTICAL);
                     Navigator.pushNamed(context, "/album");
                   },
                 ),

--- a/lib/screens/select_screen/edit_points_controller.dart
+++ b/lib/screens/select_screen/edit_points_controller.dart
@@ -1,9 +1,13 @@
 import 'package:flutter/material.dart';
+import 'dart:convert';
 import 'package:provider/provider.dart';
 import 'package:video_player/video_player.dart';
 import 'package:chewie/chewie.dart';
+import 'package:http/http.dart' as http;
+import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:simple_gradient_text/simple_gradient_text.dart';
 
+import 'package:krosscutting_app/provider/video_direction_provider.dart';
 import 'package:krosscutting_app/screens/select_screen/custom_video_progress_indicator.dart';
 import 'package:krosscutting_app/screens/select_screen/video_manager.dart';
 import 'package:krosscutting_app/widgets/purple_gradient_icon_button.dart';
@@ -12,7 +16,6 @@ import 'package:krosscutting_app/widgets/green_overlap_gradient_icon_button.dart
 
 class VideoControllerPage extends StatefulWidget {
   final int index;
-
   const VideoControllerPage({super.key, required this.index});
 
   @override
@@ -20,9 +23,73 @@ class VideoControllerPage extends StatefulWidget {
 }
 
 class _VideoControllerPageState extends State<VideoControllerPage> {
+  int trimTimeStringToInt(String timeString) {
+    String seconds = timeString.split(":").last;
+    int milliSeconds = int.parse(seconds.split(".").last);
+    int finalSeconds = int.parse(seconds.split(".").first);
+
+    if (milliSeconds > 500000) {
+      finalSeconds = finalSeconds + 1;
+    }
+
+    return finalSeconds;
+  }
+
+  void clickGreenOverlapGradientIconButton(pointsData, direction) {
+    postPoints(pointsData, direction);
+    //여기에서 일정시간마다 GET요청을 보내는 함수를 실행합니다.
+  }
+
+  Future<http.Response> postPoints(
+    pointResultData,
+    direction,
+  ) async {
+    String jsonEncodedData = json.encode(pointResultData);
+    var url = Uri.parse(
+        "${dotenv.env["SERVER_HOST"]}/videos/compilations/$direction");
+    var response = await http.post(
+      url,
+      headers: <String, String>{
+        "Content-Type": "application/json; charset=UTF-8",
+      },
+      body: jsonEncodedData,
+    );
+
+    if (response.statusCode == 201) {
+      print("편집작업종료");
+      //TODO: 편집작업완료
+    } else {
+      //TODO: 유저에게안내
+    }
+
+    return response;
+  }
+
+  formattingPointsData(pointsData) {
+    Map<String, int> startPointListMap = {
+      "mainStartPoint": pointsData["startPointList"][0],
+      "subOneStartPoint": pointsData["startPointList"][1],
+      "subTwoStartPoint": pointsData["startPointList"][2],
+    };
+
+    Map<String, List> editPointListMap = {
+      "mainEditPoint": pointsData["editPointList"][0],
+      "subOneEditPoint": pointsData["editPointList"][1],
+      "subTwoEditPoint": pointsData["editPointList"][2],
+    };
+
+    Map<String, Map> result = {
+      "startPoints": startPointListMap,
+      "selectedEditPoints": editPointListMap,
+    };
+
+    return result;
+  }
+
   @override
   Widget build(BuildContext context) {
     final videoManager = Provider.of<VideoManager>(context);
+    final videoDirection = Provider.of<VideoDirectionProvider>(context);
     final controller = videoManager.controllers[widget.index];
     final isLastVideo =
         videoManager.currentIndex == videoManager.controllers.length - 1;
@@ -48,11 +115,12 @@ class _VideoControllerPageState extends State<VideoControllerPage> {
               child: Row(
                 children: [
                   buildPurpleOverlapGradientIconButton(
-                      icon: Icons.arrow_back_rounded,
-                      onPressed: () {
-                        videoManager.setEditPage(false);
-                        Navigator.of(context).pop();
-                      }),
+                    icon: Icons.arrow_back_rounded,
+                    onPressed: () {
+                      videoManager.setEditPage(false);
+                      Navigator.of(context).pop();
+                    },
+                  ),
                   const Spacer(),
                   GradientText(
                     videoManager.currentTitle,
@@ -80,10 +148,40 @@ class _VideoControllerPageState extends State<VideoControllerPage> {
                   const Spacer(),
                   if (isLastVideo)
                     buildGreenOverlapGradientIconButton(
-                        icon: Icons.arrow_forward_rounded,
-                        onPressed: () {
-                          Navigator.of(context).pushNamed("/progress");
-                        })
+                      icon: Icons.arrow_forward_rounded,
+                      onPressed: () {
+                        List<List<Duration>> editPointListStatus =
+                            videoManager.editPointList;
+                        List<List<Duration>> startPointListStatus =
+                            videoManager.startPointList;
+
+                        List<List<int>> editPointList =
+                            editPointListStatus.map((eachVideoEditPointList) {
+                          return eachVideoEditPointList.map((editPointTime) {
+                            return trimTimeStringToInt(
+                                editPointTime.toString());
+                          }).toList();
+                        }).toList();
+
+                        List<int> startPointList =
+                            startPointListStatus.map((eachVideoStartPointList) {
+                          return trimTimeStringToInt(
+                              eachVideoStartPointList[0].toString());
+                        }).toList();
+
+                        Map<String, List> pointsData = {
+                          "editPointList": editPointList,
+                          "startPointList": startPointList,
+                        };
+
+                        var pointResultData = formattingPointsData(pointsData);
+
+                        clickGreenOverlapGradientIconButton(
+                          pointResultData,
+                          videoDirection.direction,
+                        );
+                      },
+                    )
                   else
                     const SizedBox(width: 60),
                 ],

--- a/lib/screens/select_screen/video_manager.dart
+++ b/lib/screens/select_screen/video_manager.dart
@@ -149,6 +149,8 @@ class VideoManager with ChangeNotifier {
   }
 
   String get currentTitle => titles[currentIndex];
+  List<List<Duration>> get startPointList => startPoints;
+  List<List<Duration>> get editPointList => editPoints;
 
   @override
   void dispose() {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -300,26 +300,26 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "78eb209deea09858f5269f5a5b02be4049535f568c07b275096836f01ea323fa"
+      sha256: "7f0df31977cb2c0b88585095d168e689669a2cc9b97c309665e3386f3e9d341a"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.0"
+    version: "10.0.4"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: b46c5e37c19120a8a01918cfaf293547f47269f7cb4b0058f21531c2465d6ef0
+      sha256: "06e98f569d004c1315b991ded39924b21af84cf14cc94791b8aea337d25b57f8"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.1"
+    version: "3.0.3"
   leak_tracker_testing:
     dependency: transitive
     description:
       name: leak_tracker_testing
-      sha256: a597f72a664dbd293f3bfc51f9ba69816f84dcd403cdac7066cb3f6003f3ab47
+      sha256: "6ba465d5d76e67ddf503e1161d1f4a6bc42306f9d66ca1e8f079a47290fb06d3"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.1"
+    version: "3.0.1"
   lints:
     dependency: transitive
     description:
@@ -348,10 +348,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: d584fa6707a52763a52446f02cc621b077888fb63b93bbcb1143a7be5a0c0c04
+      sha256: "7687075e408b093f36e6bbf6c91878cc0d4cd10f409506f7bc996f68220b9136"
       url: "https://pub.dev"
     source: hosted
-    version: "1.11.0"
+    version: "1.12.0"
   mime:
     dependency: transitive
     description:
@@ -537,10 +537,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "5c2f730018264d276c20e4f1503fd1308dfbbae39ec8ee63c5236311ac06954b"
+      sha256: "9955ae474176f7ac8ee4e989dadfb411a58c30415bcfb648fa04b2b8a03afa7f"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.1"
+    version: "0.7.0"
   typed_data:
     dependency: transitive
     description:
@@ -601,10 +601,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: b3d56ff4341b8f182b96aceb2fa20e3dcb336b9f867bc0eafc0de10f1048e957
+      sha256: a2662fb1f114f4296cf3f5a50786a2d888268d7776cf681aa17d660ffa23b246
       url: "https://pub.dev"
     source: hosted
-    version: "13.0.0"
+    version: "14.0.0"
   wakelock_plus:
     dependency: transitive
     description:


### PR DESCRIPTION
# KanBan Title
- 배정된 칸반은 따로 없습니다.

# Tasks in detail - checkList
- [x] 서버와 앱 연결작업을 진행합니다.
- [x] 필요한 전역상태를 추가하고, 재정립합니다.
- [x] 현재까지의 작업을 모두 연결합니다.
- [x] 버튼 클릭시 라우터 설정 및 서버에게 정보를 전달하도록 합니다.
- [x] 전달되는 정보는 기존 서버의 자료와 동일해야 합니다.

# Description
- 가로와 세로영상 선택 후 비디오 선택페이지에서 NEXT버튼을 누르면 비디오 편집 페이지로 이동합니다.
- 이때 이전 페이지에서 리로드버튼(민트색버튼)을 눌러 새로 영상을 선택했을 때 영상이 다시 변경되도록 합니다.
- 시작페이지와 편집페이지를 모두 입력받아 서버에 전달합니다.

# Concern
- 편집점,시작점 전달 버튼: `edit_points_controller.dart` 파일의 buildGreenOverlapGrandientIconButton의 onPressed 이벤트 내에서 videoManager를 소비해야 합니다. 따라서 분리를 진행하지 않았습니다. 해당 데이터를 소비하기 위한 형태로 가공하고, 서버에 제공하기 위한 형태로 재가공합니다. postPoints 함수를 호출하여 서버에 데이터를 전달합니다. 현재 해당 컴포넌트는 리팩터링이 필요합니다.

아래는 추가 TODO 입니다! 함께 확인 부탁드립니다.
 - [ ] Navigator 추가하여 프로세싱 페이지로 이동 (/progress)
 - [ ] GET 요청을 반복적으로 보낼 수 있는 함수가 실행되는 시점 확인하기 (/progress)
 - [ ] 서버에 데이터를 넘기는 과정을 리팩터링


# remarks
- 가로영상과 세로영상 선택시 전역상태 (lib/ios/provider/video_directio_provider.dart)가 변경됩니다.
- 위에서 선택된 전역상태를 통하여 추후 URL을 전달할 수 있도록 하였습니다(/vertical, /horizontal).
- MultiProvider를 도입하여 여러 provider를 사용할 수 있도록 하였습니다.
- 파일보내기 버튼 : `embedded-album.dart` 파일 내에 `GradientButton` 인 NEXT 버튼 클릭 시 파일을 서버에 보냄과 동시에 
 비디오 편집 창으로 이동합니다.
- 앱 클라이언트에서 file경로를 받아 파일 상태로 사용하려면 File()로 감싸야합니다. 이때 File은 `import 'dart:io';`를 임포트하세요.
-  http 를 사용하기 위한 임포트는 `import 'package:http/http.dart' as http;`이며, `pubspec.yaml`의 `cupertino_http: ^1.3.0` 임에 유의해주세요.
- `import 'dart:convert';`를 통해 json.decode를 사용할 수 있습니다. 데이터 송수신시 임포트하세요.

<br>

# 주의 사항
- [x] PR 크기는 300~500줄로 하되 최대 1000줄 미만으로 합니다.
- [x] conflict를 모두 해결하고 PR을 올려주세요


# PR 전 체크리스트
- [x] 가장 최신 브랜치를 pull 하였습니다
- [x] base 브랜치명을 확인하였습니다
- [x] 코드 컨벤션을 모두 확인하였습니다
- [x] 브랜치명을 확인하였습니다.
- [x] 작업 중 dependency 변경사항이 있는 경우 안내해주세요!
